### PR TITLE
Added 'pkg-resources' issue and ubuntu reboot instructions

### DIFF
--- a/source/deployment.md
+++ b/source/deployment.md
@@ -63,6 +63,12 @@ To reload the server (after a code update)
     4. Reload NGINX and Daphne  
     5. Run django_background_tasks 
 
+#### Restarting Ubuntu
+If you need to restart Ubuntu, run the following:
+```bash ~/cloud_station_deployment/configure_web_server.sh```
+This procedure is needed to restart redis.
+
+
 ## AWS RDS (Aurora engine)
 Note that the project uses SQLite due to its low cost and ease of use with Django. However, AWS RDS can be configured for scalability and robustness. 
 1. Launch an RDS instance on AWS with Aurora with MySQL compatibility
@@ -133,3 +139,6 @@ Note that the project uses SQLite due to its low cost and ease of use with Djang
     sudo systemctl enable docker
     sudo docker run -p 6379:6379 -d redis:2.8
     ```
+5. If you are using a Python version past 3.6, Python does not like "pkg-resources" anymore. Go to the requirements.txt file and comment out the following line:
+'''pkg-resources==0.0.0''' 
+


### PR DESCRIPTION
Leaving instructions / troubleshoot regarding the following issues
- restarting an ubuntu instance
- error message when using version later than Python 3.6 regarding 'pkg-resources'